### PR TITLE
Feature/entry point from config

### DIFF
--- a/src/gridengineapp/__init__.py
+++ b/src/gridengineapp/__init__.py
@@ -1,15 +1,19 @@
+from gridengineapp.data_passing import FileEntity, PandasFile, ShelfFile
 from gridengineapp.delete import qdel
+from gridengineapp.exceptions import NodeMisconfigurationError
+from gridengineapp.graph_choice import execution_ordered
+from gridengineapp.identifier import IntegerIdentifier, StringIdentifier
+from gridengineapp.job import Job
+from gridengineapp.main import entry
 from gridengineapp.status import qstat, qstat_short, check_complete
 from gridengineapp.submit import qsub, qsub_template
+from gridengineapp.gridparser import GridParser, ArgumentError
 
-from gridengineapp.data_passing import FileEntity, PandasFile, ShelfFile
-from gridengineapp.job import Job
-from gridengineapp.identifier import IntegerIdentifier, StringIdentifier
-from gridengineapp.main import entry
-from gridengineapp.exceptions import NodeMisconfigurationError
 
 __all__ = [
     "qdel", "qstat", "qstat_short", "qsub", "qsub_template",
+    "GridParser",
+    "ArgumentError",
     "check_complete",
     "FileEntity",
     "PandasFile",
@@ -18,5 +22,6 @@ __all__ = [
     "IntegerIdentifier",
     "StringIdentifier",
     "entry",
+    "execution_ordered",
     "NodeMisconfigurationError",
 ]

--- a/src/gridengineapp/gridparser.py
+++ b/src/gridengineapp/gridparser.py
@@ -1,0 +1,25 @@
+from argparse import ArgumentParser
+from logging import getLogger
+
+LOGGER = getLogger(__name__)
+
+
+class ArgumentError(Exception):
+    """An error for command-line arguments."""
+
+
+class GridParser(ArgumentParser):
+    def error(self, message):
+        """Override the base class because it calls sys.exit.
+        This library uses the parser as an internal tool,
+        not just for user interaction. For instance, it's used
+        in testing, where an exception is more appropriate.
+
+        If the status is 0, that means nothing is wrong, and
+        the user requested ``--help``, so, yes, exit.
+
+        Otherwise, print a message to standard error
+        and raise an exception.
+        """
+        LOGGER.error(message)
+        raise ArgumentError(message)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,7 +1,9 @@
 from configparser import ConfigParser
 from pathlib import Path
 
-from gridengineapp.config import shell_directory, configuration
+from gridengineapp.config import (
+    shell_directory, configuration, installed_config_parsers
+)
 
 
 def test_shell_directory():
@@ -33,3 +35,10 @@ def test_use_outside_configuration():
     assert "project" in config
     # And later queries get the overwritten one.
     assert config["queues"] == "i.q"
+
+
+def test_find_installed():
+    installed = installed_config_parsers()
+    if len(installed) > 0:
+        for parameters in installed:
+            assert parameters.has_section("gridengineapp")

--- a/tests/test_gridparser.py
+++ b/tests/test_gridparser.py
@@ -1,0 +1,22 @@
+import pytest
+
+from gridengineapp import GridParser, ArgumentError
+
+
+def test_grid_parser():
+    """Happy path."""
+    gp = GridParser()
+    gp.add_argument("--hi", action="store_true")
+    args = gp.parse_args(["--hi"])
+    assert args.hi
+
+
+def test_grid_parser_exception():
+    """A wrong argument raises an exception without exiting."""
+    gp = GridParser()
+    gp.add_argument("--takes-arg", type=int)
+    args = gp.parse_args(["--takes-arg", "37"])
+    assert args.takes_arg == 37
+
+    with pytest.raises(ArgumentError, match="expected one argument"):
+        gp.parse_args(["--takes-arg"])


### PR DESCRIPTION
Makes argument parsing not cause exit() so that it can be used under testing and under grid engine with better logging.

Switches to using shared config.